### PR TITLE
Remove unused imports, variables and functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "core-js": "^2.1.0",
     "esdoc": "^0.4.3",
     "istanbul": "^1.0.0-alpha.2",
+    "jshint": "^2.9.2",
     "json-loader": "^0.5.4",
     "lodash": "^4.11.2",
     "lua2js": "0.0.11",

--- a/src/ASTPreprocessor.js
+++ b/src/ASTPreprocessor.js
@@ -178,9 +178,9 @@ class ASTPreprocessor {
 	}
 
 	log() {
-		let str = Array.prototype.join.call(arguments, ', ');
-		let indent = new Array(this.depth).join('  ');
-		//console.log(indent + str);
+		// let str = Array.prototype.join.call(arguments, ', ');
+		// let indent = new Array(this.depth).join('  ');
+		// console.log(indent + str);
 	}
 
 	enter(a) {
@@ -340,7 +340,7 @@ class ASTPreprocessor {
 
 	exitProgram(a) {
 		this.scopeStack.shift();
-		var vars = this.varStack.shift();
+		this.varStack.shift();
 		//this.log("VARS:", Object.getOwnPropertyNames(a.vars).join(', '));
 	}
 

--- a/src/CompletionRecord.js
+++ b/src/CompletionRecord.js
@@ -1,7 +1,5 @@
 'use strict';
 
-let Value = require('./Value');
-
 class CompletionRecord {
 	constructor(type, value, target) {
 		if ( value === undefined ) {
@@ -63,5 +61,3 @@ CompletionRecord.BREAK = 1;
 CompletionRecord.CONTINUE = 2;
 CompletionRecord.RETURN = 3;
 CompletionRecord.THROW = 4;
-
-

--- a/src/Engine.js
+++ b/src/Engine.js
@@ -2,11 +2,9 @@
 
 const Evaluator = require('./Evaluator');
 const Realm = require('./Realm');
-const Scope = require('./Scope');
 const Value = require('./Value');
 const BridgeValue = require('./values/BridgeValue');
 const ASTPreprocessor = require('./ASTPreprocessor');
-const FutureValue = require('./values/FutureValue');
 const EasyNativeFunction = require('./values/EasyNativeFunction');
 const ClosureValue = require('./values/ClosureValue');
 
@@ -262,7 +260,6 @@ class Engine {
 	 */
 	fork() {
 		let engine = new Engine(this.options);
-		var scope = this.globalScope;
 
 		engine.realm = this.realm;
 

--- a/src/Evaluator.js
+++ b/src/Evaluator.js
@@ -2,13 +2,7 @@
 
 const Value = require('./Value');
 const CompletionRecord = require('./CompletionRecord');
-const ClosureValue = require('./values/ClosureValue');
-const ObjectValue = require('./values/ObjectValue');
-const FutureValue = require('./values/FutureValue');
-const RegExpValue = require('./values/RegExpValue');
-const PropertyDescriptor = require('./values/PropertyDescriptor');
 const ErrorValue = require('./values/ErrorValue');
-const ArrayValue = require('./values/ArrayValue');
 const EvaluatorInstruction = require('./EvaluatorInstruction');
 
 class Frame {
@@ -21,7 +15,6 @@ class Frame {
 class Evaluator {
 	constructor(realm, n, s) {
 		this.realm = realm;
-		let that = this;
 		this.lastValue = null;
 		this.ast = n;
 		this.defaultYieldPower = 5;
@@ -40,7 +33,6 @@ class Evaluator {
 	}
 
 	pushAST(n, s) {
-		let that = this;
 		let gen = n ? this.branch(n,s) : (function*() {
 			return yield EvaluatorInstruction.stepMinor;
 		})();
@@ -243,10 +235,6 @@ class Evaluator {
 					this.lastValue = val;
 					return true;
 				}
-				let line = -1;
-				if ( this.topFrame.ast && this.topFrame.ast.attr) {
-					line = this.topFrame.ast.attr.pos.start_line;
-				}
 				//console.log(this.buildStacktrace(val.value.toNative()));
 				throw val.value.toNative();
 			case CompletionRecord.NORMAL:
@@ -280,7 +268,6 @@ class Evaluator {
 	}
 
 	saveFrameShortcuts() {
-		let prev = this.yieldPower;
 		if ( this.frames.length == 0 ) {
 			this.topFrame = undefined;
 			this.yieldPower = this.defaultYieldPower;

--- a/src/Realm.js
+++ b/src/Realm.js
@@ -5,7 +5,6 @@ const Value = require('./Value');
 const esprima = require('esprima');
 const CompletionRecord = require('./CompletionRecord');
 const ObjectValue = require('./values/ObjectValue');
-const PrimitiveValue = require('./values/PrimitiveValue.js');
 const StringValue = require('./values/StringValue');
 const LinkValue = require('./values/LinkValue');
 const SmartLinkValue = require('./values/SmartLinkValue');

--- a/src/Scope.js
+++ b/src/Scope.js
@@ -30,7 +30,6 @@ class Scope {
 	ref(name) {
 		var vhar = this.object.properties[name];
 		if (!vhar) return undefined;
-		var that = this;
 		var o = {
 			setValue: vhar.setValue.bind(vhar, this),
 			getValue: vhar.getValue.bind(vhar, this),

--- a/src/Value.js
+++ b/src/Value.js
@@ -7,7 +7,7 @@ const GenDash = require('./GenDash');
 let undef, nil, tru, fals, nan, emptyString, zero, one, negone, negzero, smallIntValues;
 let cache = new WeakMap();
 let bookmarks = new WeakMap();
-let ObjectValue, PrimitiveValue, StringValue, NumberValue, BridgeValue, Evaluator;
+let ObjectValue, PrimitiveValue, StringValue, NumberValue, BridgeValue;
 
 
 
@@ -143,7 +143,6 @@ class Value {
 
 	static createNativeBookmark(v, realm) {
 		var out;
-		let thiz = this;
 		if ( typeof v.call === 'function' ) {
 			switch ( realm.options.bookmarkInvocationMode ) {
 				case 'loop':
@@ -286,7 +285,7 @@ class Value {
 	 * @param {Realm} realm - The realm to use when creating resuls.
 	 * @returns {Value}
 	 */
-	*tripleEquals(other, realm) {
+	*tripleEquals(other/* , realm */) {
 		return other === this ? Value.true : Value.false;
 	}
 
@@ -406,7 +405,7 @@ class Value {
 		return nv.native;
 	}
 
-	*toPrimitiveValue(preferedType) { throw new Error('Unimplemented: Value#toPrimitiveValue'); }
+	*toPrimitiveValue(/* preferedType */) { throw new Error('Unimplemented: Value#toPrimitiveValue'); }
 	*toPrimitiveNative(preferedType) { return (yield * this.toPrimitiveValue(preferedType)).native; }
 
 	/**

--- a/src/stdlib/Array.js
+++ b/src/stdlib/Array.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const EasyObjectValue = require('../values/EasyObjectValue');
-const ObjectValue = require('../values/ObjectValue');
 const ArrayValue = require('../values/ArrayValue');
 
 class ArrayObject extends EasyObjectValue {

--- a/src/stdlib/ArrayPrototype.js
+++ b/src/stdlib/ArrayPrototype.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const EasyObjectValue = require('../values/EasyObjectValue');
-const ObjectValue = require('../values/ObjectValue');
 const ArrayValue = require('../values/ArrayValue');
 const PrimitiveValue = require('../values/PrimitiveValue');
 const CompletionRecord = require('../CompletionRecord');
@@ -47,11 +46,6 @@ function *shiftLeft(arr, start, amt) {
 class ArrayPrototype extends EasyObjectValue {
 
 	static *concat$e(thiz, args, s) {
-		let fx = Value.undef;
-		let targ = Value.undef;
-		if ( args.length > 0 ) fx = args[0];
-		if ( args.length > 1 ) targ = args[1];
-
 		var out = [];
 		var toCopy = [thiz].concat(args);
 
@@ -168,7 +162,7 @@ class ArrayPrototype extends EasyObjectValue {
 		for ( let i = 0; i < l; ++i ) {
 			if ( !thiz.has(i) ) continue;
 			let v = yield * thiz.get(i);
-			let res = yield * fx.call(targ, [v, Value.fromNative(i), thiz], s);
+			yield * fx.call(targ, [v, Value.fromNative(i), thiz], s);
 		}
 
 		return Value.undef;
@@ -255,7 +249,7 @@ class ArrayPrototype extends EasyObjectValue {
 		return Value.fromNative(l + args.length);
 	}
 
-	static *pop$e(thiz, args) {
+	static *pop$e(thiz/* , args */) {
 		yield * forceArrayness(thiz);
 		let l = yield * getLength(thiz);
 		if ( l < 1 ) return Value.undef;
@@ -330,7 +324,7 @@ class ArrayPrototype extends EasyObjectValue {
 		return acc;
 	}
 
-	static *shift$e(thiz, args) {
+	static *shift$e(thiz/* , args */) {
 		yield * forceArrayness(thiz);
 		let l = yield * getLength(thiz);
 		if ( l < 1 ) return Value.undef;
@@ -369,9 +363,6 @@ class ArrayPrototype extends EasyObjectValue {
 
 	static *splice$e(thiz, args, s) {
 		//TODO: Call ToObject() on thisz;
-
-
-		let result = [];
 
 
 		let deleteCount;
@@ -474,4 +465,3 @@ class ArrayPrototype extends EasyObjectValue {
 ArrayPrototype.prototype.wellKnownName = '%ArrayPrototype%';
 
 module.exports = ArrayPrototype;
-

--- a/src/stdlib/BooleanPrototype.js
+++ b/src/stdlib/BooleanPrototype.js
@@ -4,7 +4,7 @@ const EasyObjectValue = require('../values/EasyObjectValue');
 const Value = require('../Value');
 
 class BooleanPrototype extends EasyObjectValue {
-	static *toString$e(thiz, argz) {
+	static *toString$e(thiz/* , args */) {
 		if ( thiz.primativeValue.truthy ) return Value.fromNative('true');
 		else return Value.fromNative('false');
 	}

--- a/src/stdlib/Console.js
+++ b/src/stdlib/Console.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Value = require('../Value');
-const CompletionRecord = require('../CompletionRecord');
 
 const EasyObjectValue = require('../values/EasyObjectValue');
 

--- a/src/stdlib/Error.js
+++ b/src/stdlib/Error.js
@@ -2,11 +2,8 @@
 
 const EasyObjectValue = require('../values/EasyObjectValue');
 const ObjectValue = require('../values/ObjectValue');
-const ArrayValue = require('../values/ArrayValue');
-const PrimitiveValue = require('../values/PrimitiveValue');
 const EmptyValue = require('../values/EmptyValue');
 const ErrorValue = require('../values/ErrorValue');
-const CompletionRecord = require('../CompletionRecord');
 const PropertyDescriptor = require('../values/PropertyDescriptor');
 const Value = require('../Value');
 
@@ -53,7 +50,7 @@ class ErrorObject extends EasyObjectValue {
 		return this.makeOne();
 	}
 
-	*call(thiz, args, s, e) {
+	*call(thiz, args, s/* , e */) {
 
 		if ( thiz instanceof EmptyValue ) {
 			thiz = this.makeOne();
@@ -90,4 +87,3 @@ class ErrorObject extends EasyObjectValue {
 ErrorObject.prototype.wellKnownName = '%Error%';
 
 module.exports = ErrorObject;
-

--- a/src/stdlib/ErrorPrototype.js
+++ b/src/stdlib/ErrorPrototype.js
@@ -1,10 +1,6 @@
 'use strict';
 
 const EasyObjectValue = require('../values/EasyObjectValue');
-const ObjectValue = require('../values/ObjectValue');
-const ArrayValue = require('../values/ArrayValue');
-const PrimitiveValue = require('../values/PrimitiveValue');
-const CompletionRecord = require('../CompletionRecord');
 const Value = require('../Value');
 
 
@@ -15,7 +11,7 @@ class ErrorPrototype extends EasyObjectValue {
 	static get message() { return Value.emptyString; }
 	static get name$() { return Value.fromNative('Error'); }
 
-	static *toString(thiz, argz, s) {
+	static *toString(thiz/* , args, s */) {
 		let name = yield * (yield * thiz.get('name')).toStringNative();
 		let message = yield * (yield * thiz.get('message')).toStringNative();
 		if ( name && message ) return Value.fromNative(`${name}: ${message}`);
@@ -28,4 +24,3 @@ class ErrorPrototype extends EasyObjectValue {
 ErrorPrototype.prototype.wellKnownName = '%ErrorPrototype%';
 
 module.exports = ErrorPrototype;
-

--- a/src/stdlib/FunctionPrototype.js
+++ b/src/stdlib/FunctionPrototype.js
@@ -93,7 +93,7 @@ class FunctionPrototype extends EasyObjectValue {
 
 	}
 
-	*call(thiz, args, s) {
+	*call(/* thiz, args, s */) {
 		return EasyObjectValue.undef;
 	}
 

--- a/src/stdlib/JSON.js
+++ b/src/stdlib/JSON.js
@@ -95,15 +95,15 @@ class JSONObject extends EasyObjectValue {
 		}
 	}
 
-	static *stringify(thiz, args, s) {
+	static *stringify(thiz, args/* , s */) {
 		let arr = [];
 		let v = Value.undef;
-		let replacer = null;
+		// let replacer = null;
 		let str;
 		let strincr;
 
 		if ( args.length > 0 ) v = args[0];
-		if ( args.length > 1 ) replacer = args[1];
+		// if ( args.length > 1 ) replacer = args[1];
 		if ( args.length > 2 ) {
 			str = '';
 			if ( args[2].jsTypeName === 'number' ) {

--- a/src/stdlib/Math.js
+++ b/src/stdlib/Math.js
@@ -3,13 +3,9 @@
 const EasyObjectValue = require('../values/EasyObjectValue');
 const Value = require('../Value');
 
-function makeNumber(num) {
-	return 0 + num.toNative();
-}
-
 function wrapMathFunction(name) {
 	let fn = Math[name];
-	return function*(thiz, args, realm) {
+	return function*(thiz, args/* , realm */) {
 		let length = args.length;
 		let argz = new Array(length);
 		for ( let i = 0; i < length; ++i ) {

--- a/src/stdlib/Number.js
+++ b/src/stdlib/Number.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const EasyObjectValue = require('../values/EasyObjectValue');
-const CompletionRecord = require('../CompletionRecord');
 
 
 class NumberObject extends EasyObjectValue {
@@ -29,4 +28,3 @@ class NumberObject extends EasyObjectValue {
 
 NumberObject.prototype.wellKnownName = '%Number%';
 module.exports = NumberObject;
-

--- a/src/stdlib/ObjectPrototype.js
+++ b/src/stdlib/ObjectPrototype.js
@@ -5,6 +5,7 @@ const EasyObjectValue = require('../values/EasyObjectValue');
 const Value = require('../Value');
 const NullValue = require('../values/NullValue');
 const UndefinedValue = require('../values/UndefinedValue');
+const CompletionRecord = require('../CompletionRecord');
 
 class ObjectPrototype extends EasyObjectValue {
 	constructor(realm) {
@@ -42,13 +43,13 @@ class ObjectPrototype extends EasyObjectValue {
 	}
 	static *toLocaleString$e(thiz, args) { return yield * ObjectPrototype.toString$e(thiz, args); }
 
-	static *toString$e(thiz, args) {
+	static *toString$e(thiz/* , args */) {
 		if ( thiz instanceof UndefinedValue ) return this.fromNative('[object Undefined]');
 		if ( thiz instanceof NullValue ) return this.fromNative('[object Null]');
 		return this.fromNative('[object ' + thiz.clazz + ']');
 	}
 
-	static *valueOf$e(thiz, args) {
+	static *valueOf$e(thiz/* , args */) {
 		if ( thiz.specTypeName === 'object' ) return thiz;
 		//TODO: Need to follow the ToObject() conversion
 		return thiz;

--- a/src/stdlib/String.js
+++ b/src/stdlib/String.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const EasyObjectValue = require('../values/EasyObjectValue');
-const CompletionRecord = require('../CompletionRecord');
 const PropertyDescriptor = require('../values/PropertyDescriptor');
 
 class StringObject extends EasyObjectValue {

--- a/src/values/ArrayValue.js
+++ b/src/values/ArrayValue.js
@@ -1,10 +1,8 @@
 'use strict';
 
 
-const PrimitiveValue = require('./PrimitiveValue');
 const ObjectValue = require('./ObjectValue');
 const Value = require('../Value');
-let NumberValue;
 
 
 class ArrayValue extends ObjectValue {
@@ -80,5 +78,3 @@ class ArrayValue extends ObjectValue {
 ArrayValue.prototype.clazz = 'Array';
 
 module.exports = ArrayValue;
-
-NumberValue = require('./NumberValue');

--- a/src/values/BridgeValue.js
+++ b/src/values/BridgeValue.js
@@ -86,7 +86,7 @@ class BridgeValue extends Value {
 		this.native[name] = value.toNative();
 	}
 
-	*observableProperties(realm) {
+	*observableProperties(/* realm */) {
 		for ( let p in this.native ) {
 			yield this.makeBridge(p);
 		}

--- a/src/values/EasyObjectValue.js
+++ b/src/values/EasyObjectValue.js
@@ -4,7 +4,6 @@
 const Value = require('../Value');
 const PropertyDescriptor = require('./PropertyDescriptor');
 const ObjectValue = require('./ObjectValue');
-const CompletionRecord = require('../CompletionRecord');
 const EasyNativeFunction = require('./EasyNativeFunction');
 
 class EasyObjectValue extends ObjectValue {

--- a/src/values/EmptyValue.js
+++ b/src/values/EmptyValue.js
@@ -19,7 +19,7 @@ class EmptyValue extends Value {
 		else return Value.false;
 	}
 
-	*observableProperties(realm) {
+	*observableProperties(/* realm */) {
 		return;
 	}
 

--- a/src/values/ErrorValue.js
+++ b/src/values/ErrorValue.js
@@ -1,9 +1,7 @@
 'use strict';
 
 
-const PrimitiveValue = require('./PrimitiveValue');
 const ObjectValue = require('./ObjectValue');
-const Value = require('../Value');
 const EvaluatorInstruction = require('../EvaluatorInstruction');
 
 class ErrorInstance extends ObjectValue {
@@ -39,9 +37,8 @@ class ErrorInstance extends ObjectValue {
 		if ( !this.realm.options.extraErrorInfo ) return;
 		let evaluator = yield EvaluatorInstruction.getEvaluator();
 		if ( evaluator ) {
-			let scope = evaluator.topFrame.scope;
-			let ast = extra.ast = evaluator.topFrame.ast;
-			extra.scope = scope;
+			let scope = extra.scope = evaluator.topFrame.scope;
+			extra.ast = evaluator.topFrame.ast;
 
 			if ( extra.ast.loc ) {
 				extra.line = extra.ast.loc.start.line;

--- a/src/values/FutureValue.js
+++ b/src/values/FutureValue.js
@@ -1,5 +1,4 @@
 'use strict';
-const EmptyValue = require('./EmptyValue');
 const Value = require('../Value');
 
 function defer() {

--- a/src/values/LinkValue.js
+++ b/src/values/LinkValue.js
@@ -54,7 +54,7 @@ class LinkValue extends Value {
 		return out;
 	}
 
-	*set(name, value, s, extra) {
+	*set(name, value/* , s, extra */) {
 		this.native[name] = value.toNative();
 	}
 
@@ -110,7 +110,7 @@ class LinkValue extends Value {
 	}
 
 
-	*observableProperties(realm) {
+	*observableProperties(/* realm */) {
 		for ( let p in this.native ) {
 			yield this.makeLink(p);
 		}

--- a/src/values/NullValue.js
+++ b/src/values/NullValue.js
@@ -9,7 +9,7 @@ class NullValue extends EmptyValue {
 	get jsTypeName() { return 'object'; }
 	get specTypeName() { return 'null'; }
 
-	*tripleEquals(other, realm) {
+	*tripleEquals(other/* , realm */) {
 		return other instanceof NullValue ? Value.true : Value.false;
 	}
 
@@ -17,7 +17,7 @@ class NullValue extends EmptyValue {
 		return 'null';
 	}
 
-	*toPrimitiveValue(preferedType) { return this; }
+	*toPrimitiveValue(/* preferedType */) { return this; }
 	*toNumberValue() { return Value.zero; }
 	*toStringValue() { return Value.fromNative('null'); }
 

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -40,7 +40,6 @@ class ObjectValue extends Value {
 		var existing = this.properties[name];
 		let thiz = this;
 
-		let get;
 		if ( existing ) {
 			return new ObjRefrence(this, name, ctxthis);
 		} else {
@@ -58,7 +57,6 @@ class ObjectValue extends Value {
 
 	//Note: Returns generator by tailcall.
 	set(name, value, s, extra) {
-		let thiz = this;
 		extra = extra || {};
 		if ( !Object.prototype.hasOwnProperty.call(this.properties, name) ) {
 			if ( !this.extensable ) {
@@ -186,7 +184,7 @@ class ObjectValue extends Value {
 		return Value.false;
 	}
 
-	*observableProperties(realm) {
+	*observableProperties(/* realm */) {
 		for ( let p in this.properties ) {
 			if ( !this.properties[p].enumerable ) continue;
 			yield this.fromNative(p);
@@ -283,7 +281,7 @@ class ObjectValue extends Value {
 		return yield * prim.toNumberValue();
 	}
 
-	*toObjectValue(realm) { return this; }
+	*toObjectValue(/* realm */) { return this; }
 
 	*toStringValue() {
 		let prim = yield * this.toPrimitiveValue('string');

--- a/src/values/PrimitiveValue.js
+++ b/src/values/PrimitiveValue.js
@@ -2,7 +2,6 @@
 /* @flow */
 
 const Value = require('../Value');
-const CompletionRecord = require('../CompletionRecord');
 let StringValue;
 
 /**
@@ -31,8 +30,8 @@ class PrimitiveValue extends Value {
 		return yield * this.derivePrototype(realm).get(what, realm);
 	}
 
-	*set(what, to, realm) {
-		//Can't set primative properties.
+	*set(/* what, to, realm */) {
+		// Can't set primitive properties.
 	}
 
 
@@ -83,7 +82,7 @@ class PrimitiveValue extends Value {
 	*add(other) { return this.fromNative(this.native + (yield * other.toPrimitiveNative())); }
 
 	*inOperator(other) { return this.fromNative(this.native in other.toNative()); }
-	*instanceOf(other) { return Value.false; }
+	*instanceOf(/* other */) { return Value.false; }
 
 	*unaryPlus() { return this.fromNative(+this.native); }
 	*unaryMinus() { return this.fromNative(-this.native); }
@@ -116,7 +115,7 @@ class PrimitiveValue extends Value {
 		return typeof this.native;
 	}
 
-	*toPrimitiveValue(preferedType) { return this; }
+	*toPrimitiveValue(/* preferedType */) { return this; }
 	*toStringValue() {
 		if ( typeof this.native === 'string' ) return this;
 		return this.fromNative(String(this.native));
@@ -132,5 +131,3 @@ class PrimitiveValue extends Value {
 module.exports = PrimitiveValue;
 
 StringValue = require('./StringValue');
-
-

--- a/src/values/RegExpValue.js
+++ b/src/values/RegExpValue.js
@@ -1,7 +1,6 @@
 'use strict';
 
 
-const PrimitiveValue = require('./PrimitiveValue');
 const ObjectValue = require('./ObjectValue');
 const Value = require('../Value');
 

--- a/src/values/UndefinedValue.js
+++ b/src/values/UndefinedValue.js
@@ -5,7 +5,7 @@ const Value = require('../Value');
 class UndefinedValue extends EmptyValue {
 	toNative() { return undefined; }
 	get jsTypeName() { return 'undefined'; }
-	*tripleEquals(other, realm) {
+	*tripleEquals(other/* , realm */) {
 		return other instanceof UndefinedValue ? Value.true : Value.false;
 	}
 
@@ -15,7 +15,7 @@ class UndefinedValue extends EmptyValue {
 		return 'undefined';
 	}
 
-	*toPrimitiveValue(preferedType) { return this; }
+	*toPrimitiveValue(/* preferedType */) { return this; }
 	*toNumberValue() { return Value.nan; }
 	*toStringValue() { return Value.fromNative('undefined'); }
 


### PR DESCRIPTION
I think the code is easier to read and understand after removing dead code and unused declarations. This is just a small clean up suggestion.

This fixes several warnings from the JSHint output regarding unused declarations. I've only kept a few of them that could be useful for logging. Please take your time reviewing these changes.

I've also added a missing `CompletionRecord` import in the `ObjectPrototype.js` file.

I've added `jshint` as a dev dependency so that `npm run lint` will use the local dependency instead of relying on a global JSHint installation.
