### PR TITLE
Don't load startup language code if realm is provided

### DIFF
--- a/src/Engine.js
+++ b/src/Engine.js
@@ -57,7 +57,7 @@ class Engine {
 		this.evaluator.defaultYieldPower = this.options.yieldPower;
 		this.evaluator.yieldPower = this.options.yieldPower;
 
-		if ( this.language.startupCode ) {
+		if ( this.language.startupCode && !realm ) {
 			this.loadLangaugeStartupCode();
 		}
 


### PR DESCRIPTION
Spoke to Rob. This will not load the language if a realm is provided,
which is what happens when we call `.fork()` from Python.